### PR TITLE
Bump ruby version minimum to 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   test:
-
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: [2.6, 2.7, '3.0', 3.1, 3.2]
+        ruby-version:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
 
     runs-on: ${{ matrix.os }}
 

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,3 @@
 # For available configuration options, see:
 #   https://github.com/standardrb/standard
-ruby_version: 2.6
+ruby_version: 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,10 @@ GEM
     method_source (1.0.0)
     minitest (5.18.0)
     parallel (1.22.1)
-    parser (3.2.2.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
@@ -45,6 +47,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -55,4 +58,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.4.10
+   2.4.22

--- a/lint_roller.gemspec
+++ b/lint_roller.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A plugin specification for linter and formatter rulesets"
   spec.homepage = "https://github.com/standardrb/lint_roller"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Context: https://github.com/standardrb/standard/pull/657

This one might need some followup re: dependency bumps and bundling. Was hitting some oddities locally with it wanting to version bump more than I wanted into this PR. Not sure if that's unique to my local setup (running just-released 3.3.6) or something that will show up on CI. Will review as followup if CI has issues.