### PR TITLE
Add `to_s` representation to `LintRoller::Plugin`

### DIFF
--- a/lib/lint_roller/plugin.rb
+++ b/lib/lint_roller/plugin.rb
@@ -24,5 +24,15 @@ module LintRoller
     def <=>(other)
       about.name <=> other.about.name
     end
+
+    def to_s
+      if about.name && about.version
+        "#{about.name} (#{about.version})"
+      elsif about.name
+        about.name
+      else
+        inspect
+      end
+    end
   end
 end

--- a/test/lib/plugin_test.rb
+++ b/test/lib/plugin_test.rb
@@ -87,6 +87,8 @@ module LintRoller
       assert sample_roller.supported?(Context.new(runner: :standard))
       refute sample_roller.supported?(Context.new(runner: :rufo))
 
+      assert_equal sample_roller.to_s, "sample-roller (1.2.3)"
+
       assert_equal Rules.new(
         type: :path,
         config_format: :rubocop,


### PR DESCRIPTION
While developing https://github.com/rubocop/rubocop/pull/13792, I noticed that `LintRoller::Plugin` lacks a string representation. For example, in RuboCop, there is a feature to display a list of plugins using the `rubocop -V` command:

```console
$ bundle exec rubocop -V
1.71.2 (using Parser 3.3.7.0, rubocop-ast 1.38.0, analyzing as Ruby 2.7, running on ruby 3.4.1) [x86_64-darwin23]
  - rubocop-performance 1.23.1
  - rubocop-rake 0.6.0
  - rubocop-rspec 3.4.0
```

In cases like this, having a string representation would simplify things.

I'm not sure what the best string representation would be, but I have chosen to include the name and version as they provide the minimal and most easily identifiable details.