### PR TITLE
[Doc] Fix incorrect hyperlink in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ end
 
 And that's pretty much it. Just a declarative way to identify your plugin,
 detect whether it supports the given
-[LintRoller::Context](/lib/lint_roller_context.rb) (e.g. the current `runner`
+[LintRoller::Context](/lib/lint_roller/context.rb) (e.g. the current `runner`
 and `engine` and their respective `_version`s), for which the plugin will
 ultimately its configuration as a [LintRoller::Rules](/lib/lint_roller/rules.rb)
 object.


### PR DESCRIPTION
This PR corrects the following incorrect URL.

```diff
-https://github.com/standardrb/lint_roller/blob/main/lib/lint_roller_context.rb
+https://github.com/standardrb/lint_roller/blob/main/lib/lint_roller/context.rb
```