### PR TITLE
Delegate comparability to About

### DIFF
--- a/lib/lint_roller/about.rb
+++ b/lib/lint_roller/about.rb
@@ -5,5 +5,11 @@ module LintRoller
     :homepage, # "https://github.com/testdouble/standard-performance"
     :description, # "A configuration of rubocop-performance rules to make Ruby go faster"
     keyword_init: true
-  )
+  ) do
+    include Comparable
+
+    def <=>(other)
+      values <=> [other.name, other.version, other.homepage, other.description]
+    end
+  end
 end

--- a/lib/lint_roller/plugin.rb
+++ b/lib/lint_roller/plugin.rb
@@ -22,7 +22,7 @@ module LintRoller
     end
 
     def <=>(other)
-      about.name <=> other.about.name
+      about <=> other.about
     end
   end
 end


### PR DESCRIPTION
The sorting of Plugins is via their metadata, so push that logic into the About class.

When comparing, we now compare using _all_ the members of About. This will give us a more stable sort, in cases where some attributes are equal. Also of note, the implementation of `About#<=>` does _not_ assume that the other object is implemented with a Struct. (It does not depend on `#values`.) Instead, it explicitly fetches the desired attributes to compare against, depending only on the contract that the other object respond to those attributes.